### PR TITLE
Allow db_svc to be either "mongodb" or "mongodb-nationalparks"

### DIFF
--- a/bin/db.js
+++ b/bin/db.js
@@ -5,7 +5,8 @@ var db_svc    = config.get('db_svc_name'),
 // Attempt to autoconfigure for PG and MongoDB
 if( db_svc == "postgresql"){
   db_export = require('./pgdb.js');
-}else if( db_svc == "mongodb"){
+}else if(db_svc.indexOf("mongodb") != -1){
+  // Depending on OCP version, db_svc may be 'mongodb-nationalparks' not 'mongodb'
   db_export = require('./mongodb.js');
 }else{
   console.log("ERROR: DB Configuration missing! Failed to autoconfigure database");


### PR DESCRIPTION
Updating so this will work with ocp 3 and 4. I've tested it against both.